### PR TITLE
Add geo_dimension column to dim_geography

### DIFF
--- a/models/core/fact_forecasts.sql
+++ b/models/core/fact_forecasts.sql
@@ -11,7 +11,8 @@ with dim_geography as (
         mtn_range,
         subrange,
         latitude,
-        longitude
+        longitude,
+        concat(latitude , ",", longitude) AS geo_dimension
     from {{ ref("dim_geography") }}
 ),
 
@@ -103,6 +104,7 @@ select
     g.subrange,
     g.latitude,
     g.longitude,
+    g.geo_dimension,
     z.time_zone,
     z.utc_diff,
     s.sunrise_time,

--- a/models/core/schema.yml
+++ b/models/core/schema.yml
@@ -219,6 +219,10 @@ models:
         data_type: numeric
         description: Longitude coordinate of the mountain.
 
+      - name: geo_dimension
+        data_type: string
+        description: Field used for making geographic plots in Looker; a string of '{latitude},{longitude}'.
+
 
   - name: bridge_region_group
     description: >


### PR DESCRIPTION
This field is a string of '{latitude},{longitude}' and is used by Looker for making geographic plots.