### PR TITLE
forecast_predictions_may_2024: change time_diff to time_diff_hours

### DIFF
--- a/models/core/forecast_predictions_may_2024.sql
+++ b/models/core/forecast_predictions_may_2024.sql
@@ -85,7 +85,8 @@ select
     f.time_of_scrape,
     f.local_time_issued,
     f.local_time_of_forecast,
-    f.local_time_of_forecast - f.local_time_issued as time_diff,
+    extract(day from (f.local_time_of_forecast - f.local_time_issued)) * 24 +
+    extract(hour from (f.local_time_of_forecast - f.local_time_issued)) as time_diff_hours,
     f.forecast_time_name,
     f.forecast_status,
     f.forecast_phrase,


### PR DESCRIPTION
This is the number of hours between the forecast and the actual weather. This needed to be changed because Looker apparently doesn't play nice with interval data, and just having the number of hours is perhaps cleaner anyway